### PR TITLE
RATP-15 test: add unit tests for API, database

### DIFF
--- a/shared/src/androidUnitTest/kotlin/database/BookDatabaseCrudTest.kt
+++ b/shared/src/androidUnitTest/kotlin/database/BookDatabaseCrudTest.kt
@@ -1,0 +1,67 @@
+package database
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.junit.Before
+import org.junit.After
+import org.junit.Test
+import org.junit.Assert.*
+
+class BookDatabaseCrudTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var db: AppDatabase
+    private lateinit var queries: BookQueries
+
+    @Before
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        AppDatabase.Schema.create(driver)
+        db = AppDatabase(driver)
+        queries = db.bookQueries
+    }
+
+    @After
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun insertAndSelectByKey() {
+        queries.insertBook(
+            key = "OL1M",
+            title = "KMM Guide",
+            author = "Jane Doe",
+            imageUrl = "https://x/y.jpg",
+            publishedDate = "2023"
+        )
+
+        val one = queries.selectByKey("OL1M").executeAsOne()
+        assertEquals("KMM Guide", one.title)
+        assertEquals("Jane Doe", one.author)
+        assertEquals("2023", one.publishedDate)
+    }
+
+    @Test
+    fun updateDescription() {
+        queries.insertBook("OL2M", "Another", "John", null, null)
+        queries.updateBookDetails(key = "OL2M", description = "Great book")
+        val one = queries.selectByKey("OL2M").executeAsOne()
+        assertEquals("Great book", one.description)
+    }
+
+    @Test
+    fun deleteAllClearsTable() {
+        queries.insertBook("OL3M", "A", "B", null, null)
+        queries.insertBook("OL4M", "C", "D", null, null)
+        assertTrue(queries.selectAll().executeAsList().isNotEmpty())
+
+        queries.deleteAll()
+        assertTrue(queries.selectAll().executeAsList().isEmpty())
+    }
+
+    @Test(expected = Exception::class)
+    fun primaryKeyConflictThrows() {
+        queries.insertBook("OL5M", "A", "B", null, null)
+        queries.insertBook("OL5M", "A2", "B2", null, null) // should fail
+    }
+}

--- a/shared/src/androidUnitTest/kotlin/network/OpenLibraryServiceTest.kt
+++ b/shared/src/androidUnitTest/kotlin/network/OpenLibraryServiceTest.kt
@@ -1,0 +1,138 @@
+package network
+
+import database.AppDatabase
+import database.BookDatabase
+import database.BookQueries
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.Assert.*
+
+class OpenLibraryServiceTest {
+
+    private fun inMemoryQueries(): BookQueries {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        AppDatabase.Schema.create(driver)
+        val db = AppDatabase(driver)
+        return db.bookQueries
+    }
+
+    @Test
+    fun getBookBySubject_parsesAndCaches() = runTest {
+        val subjectJson = """{
+          "works": [
+            {
+              "title": "KMM Basics",
+              "key": "/works/OL1M",
+              "cover_id": 12345,
+              "authors": [{ "name": "Jane Doe" }],
+              "first_publish_year": 2023
+            }
+          ]
+        }"""
+
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request: HttpRequestData ->
+                    assertEquals(
+                        "https://openlibrary.org/subjects/kotlin.json?limit=10&offset=0",
+                        request.url.toString()
+                    )
+                    respond(
+                        content = subjectJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val queries = inMemoryQueries()
+        val bookDb = BookDatabase(queries)
+        val service = OpenLibraryService(client, bookDb)
+
+        val works = service.getBookBySubject("kotlin", 0)
+        assertEquals(1, works.books.size)
+        val first = works.books.first()
+        assertEquals("KMM Basics", first.title)
+        assertEquals("Jane Doe", first.author)
+        assertEquals("OL1M", first.key)
+        assertTrue(first.imageUrl.contains("covers.openlibrary.org"))
+
+        val cached = queries.selectByKey("OL1M").executeAsOne()
+        assertEquals("KMM Basics", cached.title)
+        assertEquals("Jane Doe", cached.author)
+        assertEquals("2023", cached.publishedDate)
+    }
+
+    @Test
+    fun getDetailByBook_parsesStringDescription() = runTest {
+        val detailJson = """{
+          "title": "KMM Basics",
+          "description": "A gentle intro to KMM"
+        }"""
+
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        content = detailJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val bookDb = BookDatabase(inMemoryQueries())
+        val service = OpenLibraryService(client, bookDb)
+
+        val description = service.getDetailByBook("OL1M")
+        assertEquals("A gentle intro to KMM", description)
+    }
+
+    @Test
+    fun getDetailByBook_parsesObjectDescription() = runTest {
+        val detailJson = """{
+          "title": "KMM Basics",
+          "description": { "value": "Deep dive into KMM" }
+        }"""
+
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        content = detailJson,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val bookDb = BookDatabase(inMemoryQueries())
+        val service = OpenLibraryService(client, bookDb)
+
+        val description = service.getDetailByBook("OL1M")
+        assertEquals("Deep dive into KMM", description)
+    }
+}


### PR DESCRIPTION
## Summary
Add OpenLibraryService unit tests with direct MockEngine and database checks

## Jira
https://albertjs3232.atlassian.net/jira/core/projects/ECTD/board?filter=&groupBy=status&selectedIssue=ECTD-10

## Description
Adds unit tests for OpenLibraryService.
- Tests fetching books by subject and fetching book details.
- Uses MockEngine to mock HTTP responses.
- Verifies data is correctly cached in an in-memory database.
- Covers both string and object formats for book descriptions.

## Checklist
-  HTTP requests are mocked.
-  Database CRUD action verified.